### PR TITLE
Allow configuration to supply a Nonce Store

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,9 @@ Usage for the module is fairly straightfoward.
 
 ```js
 var ltiMiddleware = require("express-ims-lti");
+var lti = require('ims-lti')
+// Optional
+// var redisClient = require('redis').createClient();
 
 // ... Construct your application ...
 
@@ -18,18 +21,24 @@ app.use(ltiMiddleware({
   // consumer_secret. The credentials option a function that accepts a key and
   // a callback to perform an asynchronous operation to fetch the secret.
   credentials: function (key, callback) {
-    // `this` is a reference to the request object.
-    var consumer = this.consumer = fetchLtiConsumer(key);
+    // use this function to dynamically look up a secret based on the key
+    // allowing you to have multiple key/secret pairs
+    // `this` is a reference to the express request object.
     // The first parameter is an error (null if there is none).
-    callback(null, key, consumer.secret);
+    // 2nd is the consumer key, we'll just pass the key we got back
+    // 3rd is the consumer secret that matches this key, used to validate the OAuth signature
+    callback(null, key, 'dynamic_secret_value_for_this_key');
   },
 
-  consumer_key: "key",       // Required if not using credentials.
-  consumer_secret: "secret", // Required if not using credentials.
+  consumer_key: "key",       // Required if not using credentials key shown above.
+  consumer_secret: "secret", // Required if not using credentials key shown above.
 
-  store: {                   // Optional.
-    type: "redis",           // If store is omitted memory will be used.
-    client: redisClient      // Required when using Redis.
-  }
+  // Optional Nonce Storage
+  // `store` expects an instance of a lti.stores.NonceStore object
+  // defaults to `new lti.stores.MemoryStore()`
+  // Examples:
+  // `store: new MyCustomNonceStore()`
+  // `store: new lti.stores.RedisStore('consumer_key', redisClient)`
+  store: new lti.stores.MemoryStore()
 }));
 ```

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -10,8 +10,8 @@ module.exports = function (userSettings) {
     throw new Error("A consumer_key and consumer_secret must be present");
   }
 
-  var options    = util._extend({nonceStore: lti.Stores.MemoryStore}, userSettings);
-  var nonceStore = new options.nonceStore();
+  var options    = util._extend({}, userSettings);
+  var nonceStore = (options.nonceStore ? options.nonceStore : new lti.Stores.MemoryStore());
 
   if (!options.credentials) {
     options.credentials = function (key, callback) {

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -5,20 +5,13 @@ function isObject (arg) {
   return typeof arg == "object" && arg !== null;
 }
 
-function getNonceStore (store) {
-  if (isObject(store) && store.type == "redis") {
-    return new lti.Stores.RedisStore(store.client);
-  }
-  return new lti.Stores.MemoryStore();
-};
-
 module.exports = function (userSettings) {
   if (!userSettings.credentials && (!userSettings.consumer_key || !userSettings.consumer_secret)) {
     throw new Error("A consumer_key and consumer_secret must be present");
   }
 
-  var options    = util._extend({}, userSettings);
-  var nonceStore = getNonceStore(options.store);
+  var options    = util._extend({nonceStore: lti.Stores.MemoryStore}, userSettings);
+  var nonceStore = new options.nonceStore();
 
   if (!options.credentials) {
     options.credentials = function (key, callback) {


### PR DESCRIPTION
The nonce stores included in the library only allow usage of `lti.stores.MemoryStore` and `lti.Stores.RedisStore`.

This PR allows you to supply an instance of any Nonce Store, allowing full control.